### PR TITLE
Suggested adjustments to memory model document

### DIFF
--- a/src/rv32.tex
+++ b/src/rv32.tex
@@ -1385,32 +1385,65 @@ Finally, AMOs with both {\tt .aq} and {\tt .rl} set are sequentially-consistent 
 The precise semantics of these annotations as they apply to RVWMO are described by the memory model rules below.
 
 \begin{commentary}
-  Although the ISA does not currently contain {\tt l\{b|h|w|d\}.aq[rl]} or {\tt s\{b|h|w|d\}.[aq]rl} instructions, we may add them as assembler pseudoinstructions to facilitate forwards compatibility with their potential future addition into the ISA.  These pseudoinstructions will generally assemble per the fence-based mappings of Section~\ref{sec:porting} until if and when the instructions are added to the ISA.  The RVWMO memory model is also designed to easily accommodate the possible future inclusion of such instructions.
+  Although the ISA does not currently contain {\tt
+    l\{b|h|w|d\}.aq[rl]} or {\tt s\{b|h|w|d\}.[aq]rl} instructions, we
+  may add them as assembler pseudoinstructions to facilitate forwards
+  compatibility with their potential future addition into the ISA.
+  These pseudoinstructions will generally assemble per the fence-based
+  mappings of Section~\ref{sec:porting} until if and when the
+  instructions are added to the ISA.  The RVWMO memory model is also
+  designed to easily accommodate the possible future inclusion of such
+  instructions.
 \end{commentary}
 
-ssubsubsection*{Dependencies}
-The definition of the RVWMO memory model depends in part on the notion of a syntactic dependency.
-A register $r$ read by an instruction $b$ has a syntactic dependency on an instruction $a$ if $a$ precedes $b$ in program order, $r$ is not {\tt x0}, and either of the following hold:
+\subsubsection*{Dependencies}
+The definition of the RVWMO memory model depends in part on the notion
+of a syntactic dependency.  A register $r$ read by an instruction $b$
+has a syntactic dependency on an instruction $a$ if $a$ precedes $b$
+in program order, $r$ is not {\tt x0}, and either of the following
+hold:
 \begin{enumerate}
-  \item $r$ is written by $a$ and read by $b$, and no other instruction between $a$ and $b$ in program order modifies $r$
-  \item There is some other instruction $i$ such that $r$ has a register dependency on $i$, a register $s$ read by $i$ has a dependency on $a$, and $s$ {\em carries a dependency} from $r$
+  \item $r$ is written by $a$ and read by $b$, and no other
+    instruction between $a$ and $b$ in program order modifies $r$
+  \item There is some other instruction $i$ such that $r$ has a
+    syntactic dependency on $i$, a register $s$ read by $i$ has a
+    dependency on $a$, and $s$ {\em carries a dependency} from $r$
 \end{enumerate}
 
-The question of whether a given instruction carries a dependency from {\em rs1} and/or {\em rs2} to {\em rd} is specified as part of the definition of each instruction; however, we also provide a summary here.
-For all instructions which read {\em rs1} and write {\em rd}, {\em rd} carries a dependency from {\em rs1}, with the exception of {\tt lb}, {\tt lh}, {\tt lw}, {\tt ld}, {\tt lr}, {\tt jalr}, and {\tt csrrw}.
-For all instructions which read {\em rs1} and {\em rs2} and write {\em rd}, {\em rd} carries a dependency from both {\em rs1} and {\em rs2}, with the exception of {\tt amoswap}, {\tt amoadd}, {\tt amoand}, {\tt amoor}, {\tt amoxor}, and {\tt amomax}, {\tt amomin}, and {\tt sc}.
+The question of whether a given instruction carries a dependency from
+{\em rs1} and/or {\em rs2} to {\em rd} is specified as part of the
+definition of each instruction; however, we also provide a summary
+here.  For all instructions which read {\em rs1} and write {\em rd},
+{\em rd} carries a dependency from {\em rs1}, with the exception of
+{\tt lb}, {\tt lh}, {\tt lw}, {\tt ld}, {\tt lr}, {\tt jalr}, and {\tt
+  csrrw}.  For all instructions which read {\em rs1} and {\em rs2} and
+write {\em rd}, {\em rd} carries a dependency from both {\em rs1} and
+{\em rs2}, with the exception of {\tt amoswap}, {\tt amoadd}, {\tt
+  amoand}, {\tt amoor}, {\tt amoxor}, and {\tt amomax}, and {\tt amomin}.
 
 The specification of how dependencies are carried through CSRs will be added in a future revision.
 
 Specific types of dependencies are defined as follows.
-First, for two instructions $a$ and $b$, $b$ has a syntactic address dependency on $a$ if a register used to calculate the address accessed by $b$ has a syntactic dependency on $a$.
-Second, $b$ has a syntactic data dependency on $a$ if $b$ is a store and a register used to calculate the data being written by $b$ has a syntactic dependency on $a$.
-Third, $b$ has a syntactic control dependency on $a$ if there exists a branch $m$ between $a$ and $b$ in program order such that a register checked as part of the condition of $m$ has a syntactic dependency on $a$.
-Finally, $b$ has a syntactic success dependency on $a$ if $a$ is a store-conditional and a register read by $b$ has a register dependency on $a$.
+\begin{itemize}
+\item For two instructions $a$ and $b$, $b$ has a syntactic address
+  dependency on $a$ if a register used to calculate the address
+  accessed by $b$ has a syntactic dependency on $a$.
+\item $b$ has a syntactic data dependency on $a$ if $b$ is a store and a register used to calculate the data being written by $b$ has a syntactic dependency on $a$.
+\item $b$ has a syntactic control dependency on $a$ if either:
+  \begin{itemize}
+  \item There exists a branch $m$ between $a$ and $b$ in program order such that a register checked as part of the condition of $m$ has a syntactic dependency on $a$, or
+  \item There exists an indirect jump $m$ between $a$ and $b$ in
+    program order such that the register used to calculate the jump
+    address of $m$ has a syntactic dependency on $a$.
+  \end{itemize}
+\end{itemize}
+
 
 \subsubsection*{Preserved Program Order}
-The global memory order for any given execution of a program respects some but not necessarily all of each hart's program order.
-The subset of program order which must be respected by the global memory order for all executions is known as {\em preserved program order}.
+The global memory order for any given execution of a program respects
+some but not necessarily all of each hart's program order.  The subset
+of program order respected by the global memory order for all
+executions is known as {\em preserved program order}.
 
 \newcommand{\ppost}{$a$ and $b$ are accesses to overlapping memory addresses, and $b$ is a store}
 \newcommand{\ppofence}{$a$ and $b$ are separated in program order by a fence, $a$ is in the predecessor set of the fence, and $b$ is in the successor set of the fence}
@@ -1430,7 +1463,7 @@ The subset of program order which must be respected by the global memory order f
 %\newcommand{\ppormwrfi}{$a$ is a paired load, $b$ is a load to an overlapping address, $b$ is a load-acquire, and there is no other store to an overlapping address between the store paired with $a$ and $b$}
 \newcommand{\pporfiaq}{$a$ is a paired store, $b$ is a load to an overlapping address, $b$ is a load-acquire, and there is no store to overlapping memory location(s) between $a$ and $b$ in program order}
 \newcommand{\ppoldstld}{$a$ and $b$ are loads, and there exists some store $m$ between $a$ and $b$ in program order such that $m$ has an address or data dependency on $a$, and $b$ reads a value written by $m$}
-\newcommand{\ppoaddrpo}{$b$ is a store, and there exists some instruction $m$ between $a$ and $b$ in program order such that $m$ has an address dependency on $a$}
+\newcommand{\ppoaddrpo}{$a$ is a load, $b$ is a store, and there exists some instruction $m$ between $a$ and $b$ in program order such that $m$ has an address dependency on $a$}
 \newcommand{\ppoctrlcfence}{$a$ and $b$ are loads, $b$ has a syntactic control dependency on $a$, and there exists a {\tt fence.i} between the branch used to form the control dependency and $b$ in program order}
 \newcommand{\ppoaddrpocfence}{$a$ is a load, there exists an instruction $m$ which has a syntactic address dependency on $a$, and there exists a {\tt fence.i} between $m$ and $b$ in program order}
 
@@ -1457,7 +1490,7 @@ memory access $a$ precedes memory access $b$ in preserved program order (and hen
       \item\label{ppo:addr} \ppoaddr
       \item\label{ppo:data} \ppodata
       \item\label{ppo:ctrl} \ppoctrl
-      \item\label{ppo:success} \pposuccess
+      %\item\label{ppo:success} \pposuccess
     \end{enumerate}
   \item Same-address load-load ordering
     \begin{enumerate}[resume]
@@ -1472,14 +1505,17 @@ memory access $a$ precedes memory access $b$ in preserved program order (and hen
     \begin{enumerate}[resume]
       \item\label{ppo:ld->st->ld} \ppoldstld
       \item\label{ppo:addrpo} \ppoaddrpo
-      \item\label{ppo:ctrlcfence} \ppoctrlcfence
-      \item\label{ppo:addrpocfence} \ppoaddrpocfence
+      %\item\label{ppo:ctrlcfence} \ppoctrlcfence
+      %\item\label{ppo:addrpocfence} \ppoaddrpocfence
     \end{enumerate}
 \end{itemize}
 
 \subsubsection*{Memory Model Axioms}
 
-An execution of a RISC-V program obeys the RVWMO memory consistency model only if it obeys the {\em load value axiom}, the {\em atomicity axiom}, and the {\em progress axiom}.
+An execution of a RISC-V program obeys the RVWMO memory consistency
+model only if there exists a memory order conforming to {\em preserved
+  program order} and that that satisfies the {\em load value axiom},
+the {\em atomicity axiom}, and the {\em progress axiom}.
 
 \newcommand{\loadvalueaxiom}{
   Each byte of each load returns the corresponding byte written by the whichever of the following two stores comes later in the global memory order:
@@ -1489,12 +1525,18 @@ An execution of a RISC-V program obeys the RVWMO memory consistency model only i
   \end{enumerate}
 }
 
-\newcommand{\atomicityaxiom}{If $r$ and $w$ are a paired load and store, and if $s$ is any store from which $r$ returns a value, then there can be no store from another hart to an overlapping memory location which follows both $r$ and $s$ and which precedes $w$ in the global memory order.}
+\newcommand{\atomicityaxiom}{If $r$ and $w$ are a paired load and
+  store, and if $s$ is any store to byte $i$ from which $r$ returns a
+  value and to which $w$ stores, then there can be no store from
+  another hart to byte $i$ following $s$ and preceding $w$ in the
+  global memory order.}
 
 \newcommand{\progressaxiom}{No event may be preceded in the global memory order by an infinite sequence of other events.}
 
 \textbf{Load Value Axiom:} \loadvalueaxiom
+
 \textbf{Atomicity Axiom:} \atomicityaxiom
+
 \textbf{Progress Axiom:} \progressaxiom
 
 \subsection{Definition of the RVTSO Memory Model}


### PR DESCRIPTION
I have made some changes.  This is my first use of GitHub, so feel free to complain if this is not the right procedure for this project.
1388c1388,1396f--I must have accidentally formatted a paragraph; I don't think there is any substantive change here.
1391,1393c1399,1404
Similar.
1395,1396c1406,1410
Changed "register dependency" to "syntactic dependency" in second item so that definition is recursive and does not use undefined term "register dependency".
1399,1401c1413,1422
Removed sc from opcodes with no dependency from rs1,rs2 to rd.
1399,1401c1413,1422
Added indirect jump to control dependency and reformatted for easier reading.
1412,1413c1443,1446
Grammatical fix.  Feel free to ask me why.
1433c1466
Added "a is a load" (so new handling of success dependency does not cause ordering after a store).
1475,1476c1508,1509
Commented out the fence.i side-effect rules.  I really feel strongly about this.  We should not carry this into a new architecture.  Some implementations may not need to flush the pipe upon fence.i, so fence.i would not have these side-effects.  Some implementations may invalidate the I-cache, which means that for performance, fence.i should be avoided for anything but synchronizing instructions to stores.
1482c1515,1518
Added "exists a memory order" and raised the PPO rules to the same level as the "axioms".
1492c1528,1532
Clarified atomicity axiom.  "Overlapping" is ambiguous when there are more than two memory operations.
