### PR TITLE
Clarify that canonical .{aq,rl,aqrl}->fence mappings must always be used

### DIFF
--- a/src/memory.tex
+++ b/src/memory.tex
@@ -1086,7 +1086,7 @@ The {\tt memory\_order\_release} mappings may use {\tt .rl} as an alternative.
     \tt amo<op>.aqrl             & \tt fence rw,rw; amo<op>; fence rw,rw \\
     \hline
   \end{tabular}
-  \caption{Mappings from {\tt .aq} and/or {\tt .rl} to fence-based implementations.  An alternative mapping places a {\tt fence rw,rw} after the existing {\tt s\{b|h|w|d|c\}} mapping rather than at the front of the {\tt l\{b|h|w|d|r\}} mapping.}
+  \caption{Canonical mappings from {\tt .aq} and/or {\tt .rl} to fence-based implementations. Alternative mappings are possible, but these canonical mappings must be used by conforming software to ensure compatibility between code produced by different toolchains.}
   \label{tab:aqrltofence}
 \end{table}
 


### PR DESCRIPTION
As suggested on https://github.com/riscv/riscv-isa-manual/pull/130, resubmitting here.

The current table caption might give the impression that the suggested
alternative mapping can be used at your discretion. However, it is
essential that the same mapping is used consistently for any code using
these primitives to access shared memory. Given that we can't guarantee
the same toolchain will be used for all such code, we must mandate the
canonical mapping is used.

To be more specific: if one translation unit used `fence rw, w;
s{b|h|w|d|c}` for stores while another used the alternative mapping and
so used `l{b|h|w|d|r}; fence r, rw` for loads, you would not end up with
the desired semantics.

This issue has been discussed on the RISC-V memory model working group
mailing list.